### PR TITLE
docs: fix docs URL to jayravaliya.com/ruby-pure-greeks/

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Pure-Ruby options Greeks (delta, gamma, theta, vega, rho), pricing, and implied volatility for vanilla European and American options. No Python, no QuantLib system dep, no native code.
 
-**Documentation, examples, and engine internals: https://jayrav13.github.io/ruby-pure-greeks/**
+**Documentation, examples, and engine internals: https://jayravaliya.com/ruby-pure-greeks/**
 
 ## Installation
 
@@ -41,7 +41,7 @@ option.price   # => 4.27
 option.delta   # => 0.42
 ```
 
-For the full API, the implied-volatility solver, how the three engines fall back to one another, validation methodology, and limitations, see the [documentation site](https://jayrav13.github.io/ruby-pure-greeks/).
+For the full API, the implied-volatility solver, how the three engines fall back to one another, validation methodology, and limitations, see the [documentation site](https://jayravaliya.com/ruby-pure-greeks/).
 
 ## Development
 

--- a/pure_greeks.gemspec
+++ b/pure_greeks.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
-  spec.metadata["documentation_uri"] = "https://jayrav13.github.io/ruby-pure-greeks/"
+  spec.metadata["documentation_uri"] = "https://jayravaliya.com/ruby-pure-greeks/"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
## Why

The Pages site is live, but the URL we shipped in 0.1.0 (\`jayrav13.github.io/ruby-pure-greeks/\`) 404s. Reason: \`jayrav13.github.io\` has a CNAME pointing at \`jayravaliya.com\`, so GitHub serves project pages from the custom domain too. The canonical URL is **https://jayravaliya.com/ruby-pure-greeks/**.

## What changes

- README.md: the \"Documentation, examples, and engine internals\" pointer + the \"see the documentation site\" link.
- pure_greeks.gemspec: \`spec.metadata[\"documentation_uri\"]\`.

The gemspec change does **not** retroactively fix 0.1.0 on RubyGems — that metadata is immutable on the published gem. The fix lands in whichever 0.1.x release we cut next. README is fine to merge alone since GitHub renders it live.

## Trigger?

This commit doesn't touch \`lib/pure_greeks/version.rb\`, so merging it does **not** trigger the release workflow. That's intentional.