### PR TITLE
release: 0.1.1 — fix documentation_uri metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-04-28
+
+### Fixed
+
+- Patch `documentation_uri` metadata so it points at https://jayravaliya.com/ruby-pure-greeks/ (the canonical docs URL). 0.1.0's metadata pointed at https://jayrav13.github.io/ruby-pure-greeks/, which 404s. RubyGems metadata is immutable per published version, so this required a patch release even though the gemspec on `main` was already correct (fixed in PR #2).
+
 ## [0.1.0] - 2026-04-26
 
 Initial release.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pure_greeks (0.1.0)
+    pure_greeks (0.1.1)
       bigdecimal (~> 3.0)
       distribution (~> 0.8)
       prime (~> 0.1)
@@ -118,7 +118,7 @@ CHECKSUMS
   prime (0.1.4) sha256=4d755ebf7c2994a6f3a3fee0d072063be3fff2d4042ebff6cd5eebd4747a225e
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
-  pure_greeks (0.1.0)
+  pure_greeks (0.1.1)
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701

--- a/lib/pure_greeks/version.rb
+++ b/lib/pure_greeks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PureGreeks
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
## Summary

- Bumps `lib/pure_greeks/version.rb` to `0.1.1`.
- Adds a `## [0.1.1] - 2026-04-28` section to `CHANGELOG.md` under `### Fixed`.

## Why

0.1.0 shipped with `spec.metadata["documentation_uri"]` pointing at https://jayrav13.github.io/ruby-pure-greeks/, which 404s. The canonical docs URL is https://jayravaliya.com/ruby-pure-greeks/ (the user-pages CNAME on jayrav13/jayrav13.github.io re-routes the github.io domain to the custom one).

The gemspec on `main` was already corrected in #2, but RubyGems metadata is **immutable per published version** — anyone visiting https://rubygems.org/gems/pure_greeks/versions/0.1.0 will still see the broken URL until a new version is indexed. This is purely a metadata fix; no code change is needed.

## Test plan

- [x] `bundle exec rspec` — 46 examples, 0 failures
- [ ] CI green
- [ ] After merge, release workflow auto-publishes 0.1.1 via Trusted Publishing
- [ ] Verify `https://rubygems.org/api/v1/gems/pure_greeks.json` shows the corrected `documentation_uri`
- [ ] GitHub Release `v0.1.1` exists with auto-generated notes

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)