### PR TITLE
feat: add bin/ci-watch and bin/release-watch for CI / RubyGems monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `bin/ci-watch <pr-number> [--poll [interval]]` — wraps `gh pr checks` with structured exit codes (0 passed / 1 failed / 2 in-progress) for scripting CI verification.
+- `bin/release-watch [--poll [interval]]` — watches the release workflow run and confirms the gem is live on RubyGems with the expected version. Same exit-code shape as `ci-watch`.
+
 ## [0.1.0] - 2026-04-26
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Releases are tag-driven through CI — no manual `gem push` needed.
 3. Open a PR; CI must be green.
 4. Merge to `main`. The release workflow (`.github/workflows/release.yml`) detects the version bump, runs the test suite, builds the gem, publishes to RubyGems via [Trusted Publishing](https://guides.rubygems.org/trusted-publishing/) (no API key), creates a `vX.Y.Z` git tag, and opens a GitHub Release with auto-generated notes from the merged PRs.
 
+To monitor a release in flight, use `bin/release-watch` (single check) or `bin/release-watch --poll 30` (poll until the workflow completes and the new version indexes on RubyGems). For PR CI checks, `bin/ci-watch <pr-number> [--poll]` wraps `gh pr checks` with structured exit codes.
+
 The RubyGems version badge above refreshes automatically once the new version indexes on rubygems.org (usually within a minute).
 
 ## Contributing

--- a/bin/ci-watch
+++ b/bin/ci-watch
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Checks GitHub Actions CI status for a PR.
+# Usage: bin/ci-watch <pr-number> [--poll [interval]]
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — one or more checks failed
+#   2 — checks still in progress (single-check mode only)
+
+if [ $# -lt 1 ]; then
+  echo "Usage: bin/ci-watch <pr-number> [--poll [interval]]" >&2
+  exit 1
+fi
+
+PR_NUMBER="$1"
+shift
+
+POLL=false
+INTERVAL=10
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --poll)
+      POLL=true
+      if [ $# -ge 2 ] && [[ "$2" =~ ^[0-9]+$ ]]; then
+        INTERVAL="$2"
+        shift
+      fi
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+check_once() {
+  OUTPUT=$(gh pr checks "$PR_NUMBER" 2>&1) && {
+    echo "$OUTPUT"
+    echo ""
+    echo "All checks passed."
+    return 0
+  }
+
+  if echo "$OUTPUT" | grep -qE '\bpending\b|\bin_progress\b'; then
+    echo "$OUTPUT"
+    echo ""
+    echo "Checks still running."
+    return 2
+  else
+    echo "$OUTPUT"
+    echo ""
+    echo "CI failed."
+    return 1
+  fi
+}
+
+if [ "$POLL" = true ]; then
+  echo "Watching CI checks for PR #${PR_NUMBER} (polling every ${INTERVAL}s)..."
+  while true; do
+    rc=0
+    check_once || rc=$?
+    if [ "$rc" -eq 2 ]; then
+      echo "Polling again in ${INTERVAL}s..."
+      echo "---"
+      sleep "$INTERVAL"
+    else
+      exit "$rc"
+    fi
+  done
+else
+  rc=0
+  check_once || rc=$?
+  exit "$rc"
+fi

--- a/bin/release-watch
+++ b/bin/release-watch
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Monitors the GitHub Actions release workflow and confirms the gem is live on RubyGems.
+# Usage: bin/release-watch [--poll [interval]]
+#
+# Exit codes:
+#   0 — gem published and GitHub release created
+#   1 — release workflow failed
+#   2 — release still in progress (single-check mode only)
+
+POLL=false
+INTERVAL=15
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --poll)
+      POLL=true
+      if [ $# -ge 2 ] && [[ "$2" =~ ^[0-9]+$ ]]; then
+        INTERVAL="$2"
+        shift
+      fi
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Find the most recent release workflow run
+RUN_ID=$(gh run list --workflow=release.yml --limit=1 --json databaseId --jq '.[0].databaseId' 2>&1)
+
+if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+  echo "No release workflow runs found."
+  exit 1
+fi
+
+# Get expected version from version.rb
+EXPECTED_VERSION=$(ruby -r ./lib/pure_greeks/version -e 'puts PureGreeks::VERSION')
+
+echo "Watching release workflow (run $RUN_ID) for pure_greeks v${EXPECTED_VERSION}..."
+
+check_once() {
+  STATUS=$(gh run view "$RUN_ID" --json status,conclusion --jq '"\(.status) \(.conclusion)"' 2>&1)
+  RUN_STATUS=$(echo "$STATUS" | awk '{print $1}')
+  CONCLUSION=$(echo "$STATUS" | awk '{print $2}')
+
+  case "$RUN_STATUS" in
+    completed)
+      if [ "$CONCLUSION" = "success" ]; then
+        echo "Release workflow passed."
+        echo ""
+
+        # Confirm gem is live on RubyGems
+        LIVE_VERSION=$(gem search pure_greeks --remote 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+
+        if [ "$LIVE_VERSION" = "$EXPECTED_VERSION" ]; then
+          echo "pure_greeks $LIVE_VERSION is live on RubyGems."
+          return 0
+        else
+          echo "WARNING: Workflow succeeded but RubyGems shows v${LIVE_VERSION:-none}, expected v${EXPECTED_VERSION}."
+          echo "It may take a moment for RubyGems to update. Try again shortly."
+          return 2
+        fi
+      else
+        echo "Release workflow failed (conclusion: $CONCLUSION)."
+        echo ""
+        echo "View logs: gh run view $RUN_ID --log-failed"
+        return 1
+      fi
+      ;;
+    *)
+      echo "Release workflow still running (status: $RUN_STATUS)."
+      return 2
+      ;;
+  esac
+}
+
+if [ "$POLL" = true ]; then
+  while true; do
+    rc=0
+    check_once || rc=$?
+    if [ "$rc" -eq 2 ]; then
+      echo "Polling again in ${INTERVAL}s..."
+      echo "---"
+      sleep "$INTERVAL"
+    else
+      exit "$rc"
+    fi
+  done
+else
+  rc=0
+  check_once || rc=$?
+  exit "$rc"
+fi


### PR DESCRIPTION
## Summary

- Adds `bin/ci-watch <pr-number> [--poll [interval]]` — wraps `gh pr checks` with structured exit codes (0 passed / 1 failed / 2 in-progress).
- Adds `bin/release-watch [--poll [interval]]` — watches the release workflow run and confirms the gem is live on RubyGems with the expected version. Same exit-code shape.
- Updates the README "Releasing" section with a sentence pointing at both scripts.
- Adds a `[Unreleased]` `### Added` entry to `CHANGELOG.md`.

## Why

Ported from the sibling [njtransit](https://github.com/jayrav13/njtransit) gem, which uses the same Trusted Publishing release flow. Makes CI / release verification scriptable from the terminal (and from agentic tools) without parsing freeform `gh` output.

## Edits applied vs. njtransit source

`bin/ci-watch` is gem-agnostic — copied verbatim. `bin/release-watch` needed three substitutions per the issue:

| njtransit | pure_greeks |
|---|---|
| `ruby -r ./lib/njtransit/version -e 'puts NJTransit::VERSION'` | `ruby -r ./lib/pure_greeks/version -e 'puts PureGreeks::VERSION'` |
| `gem search njtransit` | `gem search pure_greeks` |
| Log strings mentioning "njtransit" | "pure_greeks" |

## Doc-sync per CLAUDE.md

These scripts add a new way to verify a release, so the README "Releasing" section now points at them. CHANGELOG `[Unreleased]` documents both additions.

## Test plan

- [x] `bash -n bin/ci-watch` and `bash -n bin/release-watch` — syntax OK
- [x] `ruby -r ./lib/pure_greeks/version -e 'puts PureGreeks::VERSION'` — returns expected version
- [x] `bin/ci-watch` with no args returns exit 1 and usage hint
- [x] `bundle exec rspec` — 46 examples, 0 failures
- [x] `bundle exec rubocop` — 28 files, no offenses
- [ ] CI green
- [ ] After merge: try `bin/release-watch` against a real release run (will land naturally with the next version bump)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)